### PR TITLE
Allow the configuration of extra options

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,6 +36,11 @@ class fail2ban (
   $maxretry                 = 3,
   $whitelist                = ['127.0.0.1/8', '192.168.56.0/24'],
   $custom_jails             = undef,
+
+  $findtime                 = 600,
+  $ssh_retry                = 3,
+  $sshdos_retry             = 3,
+  $dropbear_retry           = 3,
 ) inherits ::fail2ban::params {
   validate_re($package_ensure, '^(absent|latest|present|purged)$')
   validate_string($package_name)

--- a/templates/trusty/etc/fail2ban/jail.conf.erb
+++ b/templates/trusty/etc/fail2ban/jail.conf.erb
@@ -31,7 +31,7 @@ bantime  = <%= scope['::fail2ban::bantime'] %>
 
 # A host is banned if it has generated "maxretry" during the last "findtime"
 # seconds.
-findtime = 600
+findtime = <%= scope['::fail2ban::findtime'] %>
 maxretry = <%= scope['::fail2ban::maxretry'] %>
 
 # "backend" specifies the backend used to get files modification.
@@ -133,7 +133,7 @@ enabled  = <%= scope['::fail2ban::jails'].include? "ssh" %>
 port     = ssh
 filter   = sshd
 logpath  = /var/log/auth.log
-maxretry = 6
+maxretry = <%= scope['::fail2ban::ssh_retry'] %>
 
 [dropbear]
 
@@ -141,7 +141,7 @@ enabled  = <%= scope['::fail2ban::jails'].include? "dropbear" %>
 port     = ssh
 filter   = dropbear
 logpath  = /var/log/auth.log
-maxretry = 6
+maxretry = <%= scope['::fail2ban::dropbear_retry'] %>
 
 # Generic filter for pam. Has to be used with action which bans all ports
 # such as iptables-allports, shorewall
@@ -173,7 +173,7 @@ enabled  = <%= scope['::fail2ban::jails'].include? "ssh-ddos" %>
 port     = ssh
 filter   = sshd-ddos
 logpath  = /var/log/auth.log
-maxretry = 6
+maxretry = <%= scope['::fail2ban::sshdos_retry'] %>
 
 
 # Here we use blackhole routes for not requiring any additional kernel support

--- a/templates/xenial/etc/fail2ban/jail.conf.erb
+++ b/templates/xenial/etc/fail2ban/jail.conf.erb
@@ -65,7 +65,7 @@ bantime  = <%= scope['::fail2ban::bantime'] %>
 
 # A host is banned if it has generated "maxretry" during the last "findtime"
 # seconds.
-findtime  = 600
+findtime  = <%= scope['::fail2ban::findtime'] %>
 
 # "maxretry" is the number of failures before a host get banned.
 maxretry = <%= scope['::fail2ban::maxretry'] %>
@@ -226,7 +226,7 @@ action = %(<%= scope['::fail2ban::action'] %>)s
 enabled = <%= scope['::fail2ban::jails'].include? "ssh" %>
 port    = ssh
 logpath = %(sshd_log)s
-maxretry = 6
+maxretry = <%= scope['::fail2ban::ssh_retry'] %>
 
 
 [sshd-ddos]
@@ -236,7 +236,7 @@ maxretry = 6
 enabled = <%= scope['::fail2ban::jails'].include? "ssh-ddos" %>
 port    = ssh
 logpath = %(sshd_log)s
-maxretry = 6
+maxretry = <%= scope['::fail2ban::sshdos_retry'] %>
 
 
 [dropbear]
@@ -244,7 +244,7 @@ maxretry = 6
 enabled  = <%= scope['::fail2ban::jails'].include? "dropbear" %>
 port     = ssh
 logpath  = %(dropbear_log)s
-maxretry = 6
+maxretry = <%= scope['::fail2ban::dropbear_retry'] %>
 
 
 [selinux-ssh]


### PR DESCRIPTION
The original module is not capable of modifying the options of
preexisting jails and the default maxretry value of 6 is too high. I
also added an option to modify the findtime as well.